### PR TITLE
Add legal disclaimers

### DIFF
--- a/LEGAL_DISCLAIMER.md
+++ b/LEGAL_DISCLAIMER.md
@@ -1,0 +1,4 @@
+This repository is provided for informational purposes only. It represents the
+compilers' good-faith interpretation of publicly accessible sources. Nothing
+here should be construed as legal advice or a personal accusation. We welcome
+corrections and will amend any statements shown to be inaccurate.

--- a/README.md
+++ b/README.md
@@ -204,3 +204,12 @@ encourage sharing of **negative or contradictory findings**. If you spot an
 error or have evidence that challenges our assumptions, please open an issue or
 pull request so the community can review it.
 
+## Legal and Conduct Disclaimer
+
+This repository presents our best understanding of publicly available
+information. The analysis and interpretations herein are offered in good faith
+for scholarly discussion. We do not claim to provide legal advice, and no part
+of this project should be read as a personal attack on any individual. If you
+identify errors or believe statements are inaccurate, please let us know so we
+can correct the record.
+

--- a/docs/hallucination_report.md
+++ b/docs/hallucination_report.md
@@ -1,5 +1,9 @@
 # AI-Generated Kenya + Nigeria Tele-PrEP Claim: Hallucination Audit
 
+> **Note**: This analysis reflects our good-faith interpretation of public
+> sources. It is offered for discussion and may contain errors. If you spot any
+> inaccuracies, please let us know so we can correct them.
+
 Paper: https://www.thelancet.com/journals/lanhiv/article/PIIS2352-3018(25)00158-4/abstract
 
 ## Hypothesis

--- a/docs/hallucination_supply_forecast.md
+++ b/docs/hallucination_supply_forecast.md
@@ -1,5 +1,9 @@
 # AI “Forecasting Supply Needs” Claim: Hallucination Audit
 
+> **Note**: This analysis reflects our reading of public documents. It is
+> provided for discussion and may contain mistakes. Please let us know if you
+> find any inaccuracies so they can be addressed.
+
 ## Hypothesis
 
 The Lancet HIV Comment's sentence _"Predictive models could further enhance these programmes by helping providers identify individuals at greatest risk of HIV acquisition, forecast supply needs, and target outreach efforts more effectively.7"_ combines ideas from multiple sources. The risk-stratification and targeted-outreach clauses are consistent with Balzer et al. (CID 2020), the cited reference. **The middle phrase—"forecast supply needs"—does not appear in Balzer et al. and instead closely matches language in a sponsor marketing document (Audere white-paper).**

--- a/docs/trace_of_claims.md
+++ b/docs/trace_of_claims.md
@@ -79,6 +79,6 @@ Thus, not only is the Comment's claim unsupported by the Audere white paper, it 
 
 The McKinsey white paper also does not include any evidence for the claim that AI could enable optimized outreach or identify geographical hotspots for intervention, as the Audere white paper claims.
 
-We assess the Lancet Comment's claim to be the direct result of AI hallucination with no factual basis.
+Based on this analysis, the Lancet Comment's claim appears to stem from AI hallucination, and we were unable to locate supporting evidence.
 
 *These links trace our reasoning but should not be seen as definitive proof. If you locate stronger evidence or spot mistakes in this chain, we would value a correction or alternative interpretation.*

--- a/docs/undisclosed_audere_coi.md
+++ b/docs/undisclosed_audere_coi.md
@@ -10,7 +10,7 @@ Workshop‐derived publications are common in global health. When produced trans
 
 3. Misleading COI disclosure: One of the lead authors holds an active Senior Advisor role with Audere (the sponsor of the white paper), yet only discloses receiving "consulting fees." Under the Lancet HIV’s published standards, all active organizational roles—financial or non-financial—must be disclosed due to their perceived influence.
 
-These omissions create a false impression of independent analysis and unbiased evidence. According to Lancet’s correction policy, missing declarations of interest clearly warrant a formal correction.
+These omissions risk creating a misleading impression of independent analysis and unbiased evidence. According to Lancet’s correction policy, missing declarations of interest appear to warrant a formal correction.
 
 ---
 
@@ -122,6 +122,6 @@ These omissions create a false impression of independent analysis and unbiased e
 
 ---
 
-In summary, the Lancet HIV Comment failed to transparently disclose key connections to Audere, including one author's active advisory role and multiple undisclosed intellectual contributions from seven authors. This clearly constitutes a significant disclosure gap under the journal’s own guidelines, warranting a formal correction.
+In summary, the Lancet HIV Comment failed to transparently disclose key connections to Audere, including one author's active advisory role and multiple undisclosed intellectual contributions from seven authors. This appears to constitute a significant disclosure gap under the journal’s own guidelines and may warrant a formal correction.
 
 > **Limitations**: This document relies solely on publicly available information. If any affiliations or disclosures have been updated or clarified, please let us know so we can correct the record.


### PR DESCRIPTION
## Summary
- add Legal and Conduct disclaimer to README
- include a standalone LEGAL_DISCLAIMER file
- rephrase strong language in conflict-of-interest and trace documents
- add note disclaimers to hallucination audit docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_68687c9bbc60832b944ebb24004f3210